### PR TITLE
Set the message subject with the contents of <head> / <title>

### DIFF
--- a/stationery/src/chrome/content/composer_utils.jsm
+++ b/stationery/src/chrome/content/composer_utils.jsm
@@ -110,6 +110,23 @@ Stationery.cleanUpDomOfNewlyLoadedTemplate = function(editor /*nsIEditor*/) {
   recurse(editor.rootElement.parentNode.childNodes);
 }
 
+Stationery.getSubject = function(editor /*nsIEditor*/) {
+  function recurse(nodes) {
+    for (let i = 0 ; i < nodes.length; i++) {
+      const node = nodes[i];
+      if (node.nodeName == "TITLE") {
+        return node.innerText;
+      }
+
+      if (node.hasChildNodes()) {
+        const result = recurse(node.childNodes);
+        if (result) return result;
+      }
+    }
+  }
+  return recurse(editor.rootElement.parentNode.childNodes);
+}
+
 Stationery.getTemplatePlaceholder = function(win, nodes, type) {
   if (!nodes) { //initialize recurrency
     return Stationery.getTemplatePlaceholder(win, win.GetCurrentEditor().rootElement.childNodes, type);

--- a/stationery/src/chrome/content/stationery-composer.js
+++ b/stationery/src/chrome/content/stationery-composer.js
@@ -278,6 +278,15 @@ Stationery_.ApplyHTMLTemplate = function() {
         html = Stationery.plainText2HTML(template.Text);
             
     HTMLEditor.rebuildDocumentFromSource(html);
+
+    // Set the subject by reading the <head> / <title> element
+    if (gMsgCompose.compFields.subject == '') {
+      let subject = Stationery.getSubject(HTMLEditor);
+      if (subject) {
+        gMsgCompose.compFields.subject = subject;
+        document.getElementById("msgSubject").value = gMsgCompose.compFields.subject;  
+      }
+    }
     
     //todo: gather metadata before cleaning!
     Stationery.cleanUpDomOfNewlyLoadedTemplate(HTMLEditor);


### PR DESCRIPTION
Thunderbird writes the Message subject to the document <head><title> element when saving a message as HTML file. It sees logic to me to load this title when creating a message from template.

It only sets the Subject when the subject is empty, so it will not override the subject.